### PR TITLE
Codespell Updates

### DIFF
--- a/.codespell.words.exclude
+++ b/.codespell.words.exclude
@@ -1,2 +1,7 @@
+Hel
 ket
+noo
 ser
+vas
+vill
+vould


### PR DESCRIPTION
This should fix most of the codespell word errors by adding cases that happen 3 or more times to the codespell word list. Only ones still left are `ane` and `earnt`, that each occur a single time.